### PR TITLE
Fix undefined alertDialog reference

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import AddVendor from "./pages/AddVendor";
 import EditVendor from "./pages/EditVendor";
 import ExportDropdown from "./pages/ExportDropdown";
 import ImportVendorsPage from "./pages/ImportVendorsPage";
+import { AlertDialogProvider } from "./contexts/AlertDialogContext";
 const queryClient = new QueryClient();
 
 
@@ -29,27 +30,29 @@ const App = () => (
       <TooltipProvider>
         <Toaster />
         <Sonner />
-        <BrowserRouter>
-        <UserDetailsProvider>
-          <Layout>
-            <Routes>
-              <Route path="/" element={<Dashboard />} />
-            
-              <Route path="*" element={<NotFound />} />
-            
-                <Route path="/vendors" element={<Vendors/>} />
-              <Route path="/add-vendor" element={<AddVendorPage />} />
-              <Route path="/import-vendor" element={<ImportVendorsPage />} />
-              <Route path="/vendor-categories" element={<VendorCategories />} />
-              <Route path="/add-business-contact" element={<AddBusinessContact />} />
-              <Route path="/add-vendor-form" element={<AddVendor />} />
-              <Route path="/vendors/edit/:id" element={<EditVendor />} />
-              <Route path="/export-dropdown" element={<ExportDropdown onExport={(format) => console.log(`Exporting as ${format}`)} />} />
-            
-            </Routes>
-          </Layout>
-          </UserDetailsProvider>
-        </BrowserRouter>
+        <AlertDialogProvider>
+          <BrowserRouter>
+          <UserDetailsProvider>
+            <Layout>
+              <Routes>
+                <Route path="/" element={<Dashboard />} />
+              
+                <Route path="*" element={<NotFound />} />
+              
+                  <Route path="/vendors" element={<Vendors/>} />
+                <Route path="/add-vendor" element={<AddVendorPage />} />
+                <Route path="/import-vendor" element={<ImportVendorsPage />} />
+                <Route path="/vendor-categories" element={<VendorCategories />} />
+                <Route path="/add-business-contact" element={<AddBusinessContact />} />
+                <Route path="/add-vendor-form" element={<AddVendor />} />
+                <Route path="/vendors/edit/:id" element={<EditVendor />} />
+                <Route path="/export-dropdown" element={<ExportDropdown onExport={(format) => console.log(`Exporting as ${format}`)} />} />
+              
+              </Routes>
+            </Layout>
+            </UserDetailsProvider>
+          </BrowserRouter>
+        </AlertDialogProvider>
       </TooltipProvider>
     </AppProvider>
   </QueryClientProvider>

--- a/src/contexts/AlertDialogContext.tsx
+++ b/src/contexts/AlertDialogContext.tsx
@@ -1,0 +1,53 @@
+import React, { createContext, useContext, useState, ReactNode, useCallback } from 'react';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from '../components/ui/alert-dialog';
+
+interface AlertDialogContextType {
+  showAlertDialog: (message: string, title?: string) => void;
+}
+
+const AlertDialogContext = createContext<AlertDialogContextType | undefined>(undefined);
+
+export const useAlertDialog = () => {
+  const context = useContext(AlertDialogContext);
+  if (!context) {
+    throw new Error('useAlertDialog must be used within an AlertDialogProvider');
+  }
+  return context;
+};
+
+export const AlertDialogProvider = ({ children }: { children: ReactNode }) => {
+  const [open, setOpen] = useState(false);
+  const [message, setMessage] = useState('');
+  const [title, setTitle] = useState<string | undefined>(undefined);
+
+  const showAlertDialog = useCallback((msg: string, t?: string) => {
+    setMessage(msg);
+    setTitle(t);
+    setOpen(true);
+  }, []);
+
+  const handleClose = () => setOpen(false);
+
+  return (
+    <AlertDialogContext.Provider value={{ showAlertDialog }}>
+      {children}
+      <AlertDialog open={open} onOpenChange={setOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{title || 'Alert'}</AlertDialogTitle>
+            <AlertDialogDescription>{message}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogAction onClick={handleClose}>OK</AlertDialogAction>
+        </AlertDialogContent>
+      </AlertDialog>
+    </AlertDialogContext.Provider>
+  );
+};

--- a/src/pages/VendorCategories.tsx
+++ b/src/pages/VendorCategories.tsx
@@ -21,6 +21,7 @@ import { ChevronLeft } from "lucide-react";
 import UserDetailsContext from '@/hooks/UserDetailsContext';
 import { Edit, Delete } from '@mui/icons-material';
 import { IconButton } from '@mui/material';
+import { useAlertDialog } from "@/contexts/AlertDialogContext";
 
 interface VendorCategory {
   CategoryID: number;
@@ -44,6 +45,7 @@ const VendorCategories: React.FC = () => {
   const [missingFields, setMissingFields] = useState<string[]>([]);
 
   const navigate = useNavigate();
+  const { showAlertDialog } = useAlertDialog();
 
   const fetchVendorCategories = async () => {
     setLoading(true);
@@ -58,7 +60,7 @@ const VendorCategories: React.FC = () => {
       setCategories(response.data || []);
     } catch (error) {
       console.error('Error fetching vendor categories:', error);
-      alert('Failed to fetch vendor categories.');
+      showAlertDialog('Failed to fetch vendor categories.');
     } finally {
       setLoading(false);
     }
@@ -106,21 +108,21 @@ const VendorCategories: React.FC = () => {
             CategoryID: selectedCategoryID.toString(),
           }
         );
-        alert('Category updated successfully');
+        showAlertDialog('Category updated successfully');
       } else {
         // Add
         await axios.post(
           `${import.meta.env.VITE_API_URL}${import.meta.env.VITE_PORTNO}/purchases/AddVendorCategory`,
           payload
         );
-        alert('Category added successfully');
+        showAlertDialog('Category added successfully');
       }
 
       handleDialogClose();
       fetchVendorCategories();
     } catch (error) {
       console.error('Error saving category:', error);
-      alert('Failed to save vendor category.');
+      showAlertDialog('Failed to save vendor category.');
     }
   };
 
@@ -147,13 +149,13 @@ const VendorCategories: React.FC = () => {
 
       if (res.data?.RetString === '1') {
         setCategories(prev => prev.filter(cat => cat.CategoryID !== categoryID));
-        alert('Category deleted successfully.');
+        showAlertDialog('Category deleted successfully.');
       } else {
-        alert("Category is already in use. You can't delete it.");
+        showAlertDialog("Category is already in use. You can't delete it.");
       }
     } catch (error: any) {
       console.error('Error deleting category:', error?.response?.data || error.message);
-      alert('Failed to delete category due to a server error.');
+      showAlertDialog('Failed to delete category due to a server error.');
     } finally {
       setDeletingCategoryId(null);
     }

--- a/src/pages/Vendors.tsx
+++ b/src/pages/Vendors.tsx
@@ -27,6 +27,7 @@ import {
 import ExportDropdown from './ExportDropdown';
 
 import { CSVLink } from "react-csv";
+import { useAlertDialog } from "@/contexts/AlertDialogContext";
 interface Vendor {
   VendorID: number;
   Name: string;
@@ -215,6 +216,8 @@ const { id: VendorID } = useParams();
     }
   }, [userDetails]);
 
+  const { showAlertDialog } = useAlertDialog();
+
   const handleDeleteVendor = async (vendorID: number) => {
     if (!window.confirm("Are you sure you want to delete this vendor?")) return;
 
@@ -227,14 +230,14 @@ const { id: VendorID } = useParams();
       );
 
       if (res.data?.RetString === '1') {
-        alert("Vendor deleted successfully.");
+        showAlertDialog("Vendor deleted successfully.");
         fetchVendors();
       } else {
-        alert("Vendor is already in use. You can't delete it.");
+        showAlertDialog("Vendor is already in use. You can't delete it.");
       }
     } catch (error: any) {
       console.error("Error deleting vendor:", error?.response?.data || error.message);
-      alert("Failed to delete vendor due to a server error.");
+      showAlertDialog("Failed to delete vendor due to a server error.");
     } finally {
       setDeletingVendorId(null);
     }
@@ -292,7 +295,7 @@ const { id: VendorID } = useParams();
   setMissingFields(missing);
 
   if (missing.length > 0) {
-    alert("Please fill all required fields: " + missing.join(", "));
+    showAlertDialog("Please fill all required fields: " + missing.join(", "));
     return;
   }
 
@@ -334,11 +337,11 @@ const { id: VendorID } = useParams();
       throw new Error((data && data.message) || `Failed to update vendor: ${res.statusText}`);
     }
 
-    alert("Vendor updated successfully.");
+    showAlertDialog("Vendor updated successfully.");
     closeEditDialog();
     fetchVendors();
   } catch (err: any) {
-    alert("Error updating vendor: " + (err.message || "Unknown error"));
+    showAlertDialog("Error updating vendor: " + (err.message || "Unknown error"));
   } finally {
     setUpdateLoading(false);
   }
@@ -371,7 +374,7 @@ const { id: VendorID } = useParams();
       XLSX.writeFile(wb, `vendors.${type === "csv" ? "csv" : "xlsx"}`);
     } else if (type === "pdf") {
       if (!exportData.length) {
-        alert("No data to export.");
+        showAlertDialog("No data to export.");
         return;
       }
        const doc = new jsPDF();


### PR DESCRIPTION
Replace native `alert()` calls with a custom `AlertDialog` component for improved UI.

This PR resolves the `ReferenceError: alertDialog is not defined` by implementing a global context for the existing `AlertDialog` component and replacing all native `alert()` calls with it, providing a consistent and modern UI for alerts.