### PR TITLE
Fix await in async function

### DIFF
--- a/src/pages/AddVendor.tsx
+++ b/src/pages/AddVendor.tsx
@@ -208,10 +208,10 @@ const AddVendor = () => {
             console.error("Failed to import vendor:", payload, error);
           }
         }
-        await showAlert("CSV import completed!");
+        showAlert("CSV import completed!");
       },
       error: (err) => {
-        await showAlert("Failed to parse CSV: " + err.message);
+        showAlert("Failed to parse CSV: " + err.message);
       }
     });
   };


### PR DESCRIPTION
Remove `await` from `showAlert` calls in `Papa.parse` callbacks to fix build error.