### PR TITLE
Replace all alerts with dialog boxes

### DIFF
--- a/src/contexts/AlertDialogContext.tsx
+++ b/src/contexts/AlertDialogContext.tsx
@@ -15,6 +15,7 @@ import {
 
 interface AlertDialogContextType {
   showAlert: (message: string, title?: string) => Promise<void>;
+  showConfirm: (message: string, title?: string) => Promise<boolean>;
 }
 
 const AlertDialogContext = createContext<AlertDialogContextType | undefined>(undefined);
@@ -29,34 +30,59 @@ export const AlertDialogProvider = ({ children }: { children: ReactNode }) => {
   const [open, setOpen] = useState(false);
   const [message, setMessage] = useState('');
   const [title, setTitle] = useState<string | undefined>(undefined);
-  const [resolver, setResolver] = useState<(() => void) | null>(null);
+  const [resolver, setResolver] = useState<((result?: boolean) => void) | null>(null);
+  const [mode, setMode] = useState<'alert' | 'confirm'>('alert');
 
   const showAlert = useCallback((msg: string, t?: string) => {
     setMessage(msg);
     setTitle(t);
+    setMode('alert');
     setOpen(true);
     return new Promise<void>((resolve) => {
       setResolver(() => () => resolve());
     });
   }, []);
 
+  const showConfirm = useCallback((msg: string, t?: string) => {
+    setMessage(msg);
+    setTitle(t);
+    setMode('confirm');
+    setOpen(true);
+    return new Promise<boolean>((resolve) => {
+      setResolver(() => (result: boolean) => resolve(result));
+    });
+  }, []);
+
   const handleClose = () => {
     setOpen(false);
-    if (resolver) resolver();
+    if (resolver) resolver(mode === 'alert' ? undefined : false);
+    setResolver(null);
+  };
+
+  const handleConfirm = () => {
+    setOpen(false);
+    if (resolver) resolver(true);
     setResolver(null);
   };
 
   return (
-    <AlertDialogContext.Provider value={{ showAlert }}>
+    <AlertDialogContext.Provider value={{ showAlert, showConfirm }}>
       {children}
       <AlertDialog open={open} onOpenChange={setOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>{title || 'Notice'}</AlertDialogTitle>
-            <AlertDialogDescription>{message}</AlertDialogDescription>
+            <AlertDialogTitle>{title || (mode === 'confirm' ? 'Confirm' : 'Notice')}</AlertDialogTitle>
+            <AlertDialogDescription style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{message}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogAction onClick={handleClose}>OK</AlertDialogAction>
+            {mode === 'confirm' ? (
+              <>
+                <AlertDialogAction onClick={handleConfirm}>OK</AlertDialogAction>
+                <AlertDialogCancel onClick={handleClose}>Cancel</AlertDialogCancel>
+              </>
+            ) : (
+              <AlertDialogAction onClick={handleClose}>OK</AlertDialogAction>
+            )}
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/src/pages/VendorCategories.tsx
+++ b/src/pages/VendorCategories.tsx
@@ -43,7 +43,7 @@ const VendorCategories: React.FC = () => {
     Description: '',
   });
   const [missingFields, setMissingFields] = useState<string[]>([]);
-  const { showAlert } = useAlertDialog();
+  const { showAlert, showConfirm } = useAlertDialog();
 
   const navigate = useNavigate();
 
@@ -138,7 +138,7 @@ const VendorCategories: React.FC = () => {
   };
 
   const handleDeleteCategory = async (categoryID: number) => {
-    if (!window.confirm('Are you sure you want to delete this category?')) return;
+    if (!(await showConfirm('Are you sure you want to delete this category?'))) return;
     setDeletingCategoryId(categoryID);
 
     try {

--- a/src/pages/Vendors.tsx
+++ b/src/pages/Vendors.tsx
@@ -217,7 +217,7 @@ const { id: VendorID } = useParams();
   }, [userDetails]);
 
   const handleDeleteVendor = async (vendorID: number) => {
-    if (!window.confirm("Are you sure you want to delete this vendor?")) return;
+    if (!(await showConfirm("Are you sure you want to delete this vendor?"))) return;
 
     setDeletingVendorId(vendorID);
 
@@ -390,7 +390,7 @@ const { id: VendorID } = useParams();
   };
   
 
-  const { showAlert } = useAlertDialog();
+  const { showAlert, showConfirm } = useAlertDialog();
 
   return (
     <div className="space-y-4 px-2 sm:px-4">


### PR DESCRIPTION
Replace native `window.confirm` with a custom dialog and fix message wrapping in `AlertDialog`.

Previously, native browser `confirm` dialogs were appearing for delete actions, and custom alert messages were overflowing. This PR ensures all dialogs are consistently styled and messages are fully visible, aligning with the desired UI/UX.