### PR TITLE
Align dialog box buttons for better appearance

### DIFF
--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -63,7 +63,7 @@ const AlertDialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      "flex flex-row justify-end space-x-2",
       className
     )}
     {...props}


### PR DESCRIPTION
Ensure dialog action buttons always appear on the same line to fix visual alignment.

The previous CSS caused dialog buttons to stack vertically on smaller screens or when the dialog was not wide enough. This change forces a consistent horizontal layout for the "OK" and "Cancel" buttons.