### PR TITLE
Align dialog box buttons

### DIFF
--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -116,7 +116,6 @@ const AlertDialogCancel = React.forwardRef<
     ref={ref}
     className={cn(
       buttonVariants({ variant: "outline" }),
-      "mt-2 sm:mt-0",
       className
     )}
     {...props}


### PR DESCRIPTION
Align 'OK' and 'Cancel' buttons in dialogs by removing a conflicting margin class.

The `mt-2 sm:mt-0` class on the `AlertDialogCancel` button caused it to have an extra top margin on small screens, leading to misalignment with the 'OK' button.